### PR TITLE
Add journey and aircraft type to output data

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ exports.parseJson = function(reportsJson) {
       var plane = planeMap[hex_ident];
       var aircraft = {
         hex_ident: hex_ident,
-        callsign: plane[10],
+        callsign: plane[10], // flight number when active
+        journey: plane[11] || plane[10], // journey is set in callsign when flight is inactive
+        aircraft: plane[0],
         lat: plane[3],
         lon: plane[4],
         altitude: plane[5],


### PR DESCRIPTION
Aircraft value was just right there so that was easy to find.

The journey value consists of something like "YVR-LHR", and when the flight gets a proper flight number the flight number is put in callsign and the journey value is filled in as journey instead (this was sometimes previously undefined when it was in `planes[11]`). Not sure why it's output like that, but this always produces sensible results for me at least.
